### PR TITLE
Fix code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -13,7 +13,7 @@ export function openDesktop(url: string = '') {
   } else if (__WIN32__) {
     // https://github.com/nodejs/node/blob/b39dabefe6d/lib/child_process.js#L565-L577
     const shell = process.env.comspec || 'cmd.exe'
-    return ChildProcess.execFile(shell, ['/d', '/c', 'start', url], { env })
+    return ChildProcess.spawn(shell, ['/d', '/c', 'start', '', url], { env })
   } else if (__LINUX__) {
     return ChildProcess.spawn('xdg-open', [url], { env })
   } else {


### PR DESCRIPTION
Fixes [https://github.com/automatik-engineering/reimagined-octo-chainsaw/security/code-scanning/2](https://github.com/automatik-engineering/reimagined-octo-chainsaw/security/code-scanning/2)

To fix the problem, we should avoid passing user input directly into a shell command. Instead, we can use `ChildProcess.spawn` or `ChildProcess.execFile` with arguments to ensure that the input is not interpreted by the shell. This approach will prevent special characters in the `url` from altering the command's behavior.

Specifically, we will:
1. Replace the use of `ChildProcess.execFile` with `ChildProcess.spawn` for the Windows platform.
2. Pass the `url` as an argument to the `start` command to avoid shell interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
